### PR TITLE
junit 4.12 -> 5.2.0, picocli 3.0.0 beta 2 -> 3.0.0 release

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
-			<version>3.0.0-beta-2</version>
+			<version>3.0.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,36 @@
 			<version>1.3</version>
 		</dependency>
 		<!-- dependencies used for automated testing -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
+	        <dependency>
+       		    	<groupId>org.junit.jupiter</groupId>
+      		      	<artifactId>junit-jupiter-api</artifactId>
+           		<version>5.2.0</version>
+            		<scope>test</scope>
+        	</dependency>
+        	<dependency>
+            		<groupId>org.junit.jupiter</groupId>
+            		<artifactId>junit-jupiter-engine</artifactId>
+            		<version>5.2.0</version>
+            		<scope>test</scope>
+        	</dependency>
+       		<dependency>
+            		<groupId>org.junit.vintage</groupId>
+            		<artifactId>junit-vintage-engine</artifactId>
+            		<version>5.2.0</version>
+            		<scope>test</scope>
+        	</dependency>
+        	<dependency>
+            		<groupId>org.junit.platform</groupId>
+            		<artifactId>junit-platform-launcher</artifactId>
+            		<version>1.2.0</version>
+            		<scope>test</scope>
+        	</dependency>
+        	<dependency>
+            		<groupId>org.junit.platform</groupId>
+            		<artifactId>junit-platform-runner</artifactId>
+            		<version>1.2.0</version>
+           		 <scope>test</scope>
+        	</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>


### PR DESCRIPTION
Updated the abovely specified libraries. I hope that they do not break any automated testing. 
junit-jupiter-api (version 5.2.0) contains all of the testing classes and main code.

The junit-jupiter-engine (version 5.2.0) dependency contains the implementation of the JUnit Jupiter test engine. This dependency is required only at runtime.

The junit-vintage-engine (version 5.2.0) dependency adds support for unit tests that use JUnit 4 or JUnit 3. Again, this dependency is required only at runtime.

The junit-platform-launcher (version 1.2.0) dependency provides a public API for configuring and launching tests. This API is typically used by IDEs and build tools.

The junit-platform-runner (version 1.2.0) dependency allows us to run tests and test suites in a JUnit 4 environment.

We might not need backwards compatibility to junit 4, but I guess it won't hurt?