### PR TITLE
Picocli 3.0.0 -> 3.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 			<dependency>
 				<groupId>info.picocli</groupId>
 				<artifactId>picocli</artifactId>
-				<version>3.0.0</version>
+				<version>3.5.2</version>
 			</dependency>
 			<!-- logging -->
 			<dependency>


### PR DESCRIPTION
Hey,

the picocli developers are going absolutely ham. 
Since the 3.0.0 there have been many releases with additional features and numerous bug fixes. According to their release page there are no breaking changes.

Hence, increasing the version of picocli that we're using makes sense.