### PR TITLE
Prepare release 2.0.0

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,9 +6,8 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
-	<groupId>life.qbic</groupId>
 	<artifactId>cli-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
 	<name>CLI parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -329,51 +329,6 @@
 				<artifactId>maven-project-info-reports-plugin</artifactId>
 				<version>3.0.0</version>
 			</plugin>
-			<plugin>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>${jetty.plugin.version}</version>
-				<configuration>
-					<!-- Jetty's hot deploy enabled has been enabled by default!
-
-						 If you want to disable jetty's hot deploy feature, activate the 'jetty-cold-deploy' profile
-						 via the command line:
-
-						 mvn -P jetty-cold-deploy
-
-						 Or, alternatively, you can change your settings.xml to permanently activate this profile. 
-						 
-						 For more information on how to permanently activate a property, 
-						 see: https://maven.apache.org/settings.html#Profiles 
-						 
-						 For more information about the origin of this long comment, see: 
-						 https://github.com/qbicsoftware/parent-poms/issues/4 -->
-					<scanIntervalSeconds>${jetty.scanIntervalSeconds}</scanIntervalSeconds>
-					<useProvidedScope>true</useProvidedScope>
-					<stopPort>8005</stopPort>
-					<stopKey>STOP</stopKey>
-				</configuration>
-				<executions>
-					<execution>
-						<id>start-jetty</id>
-						<phase>pre-integration-test</phase>
-						<goals>
-							<goal>start</goal>
-						</goals>
-						<configuration>
-							<scanIntervalSeconds>${jetty.scanIntervalSeconds}</scanIntervalSeconds>
-							<daemon>true</daemon>
-						</configuration>
-					</execution>
-					<execution>
-						<id>stop-jetty</id>
-						<phase>post-integration-test</phase>
-						<goals>
-							<goal>stop</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 			<!-- unit tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>life.qbic</groupId>
 	<artifactId>parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
-	<version>1.8.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>Parent POM</name>
 	<description>Parent POM for all QBiC software</description>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.11.0</log4j.version>
-		<vaadin.version>7.7.8</vaadin.version>
+		<vaadin.version>8.9.2</vaadin.version>
 		<liferay.version>6.2.5</liferay.version>
 		<vaadin.plugin.version>7.7.8</vaadin.plugin.version>
 		<liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,9 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<log4j.version>2.11.0</log4j.version>
-		<vaadin.version>8.9.2</vaadin.version>
 		<liferay.version>6.2.5</liferay.version>
-		<vaadin.plugin.version>7.7.8</vaadin.plugin.version>
 		<liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>
 		<powermock.version>2.0.0-beta.5</powermock.version>
-		<jetty.plugin.version>9.4.10.v20180503</jetty.plugin.version>
-		<jetty.scanIntervalSeconds>2</jetty.scanIntervalSeconds>
 		<!-- whether builds should fail verification if jacoco checks fail -->
 		<verify.strict>false</verify.strict>
 	</properties>
@@ -50,24 +46,7 @@
 				<artifactId>mariadb-java-client</artifactId>
 				<version>2.0.2</version>
 			</dependency>
-			<!-- Vaadin offers a bill of materials including all of the vaadin artifacts -->
-			<dependency>
-				<groupId>com.vaadin</groupId>
-				<artifactId>vaadin-bom</artifactId>
-				<version>${vaadin.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.vaadin.addon</groupId>
-				<artifactId>vaadin-charts</artifactId>
-				<version>3.2.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.vaadin.addons</groupId>
-				<artifactId>vaadin-grid-util</artifactId>
-				<version>1.0.0</version>
-			</dependency>
+
 			<dependency>
 				<groupId>org.docx4j</groupId>
 				<artifactId>docx4j</artifactId>
@@ -77,19 +56,6 @@
 				<groupId>org.apache.poi</groupId>
 				<artifactId>poi-ooxml</artifactId>
 				<version>3.17</version>
-			</dependency>
-			<!-- Liferay -->
-			<dependency>
-				<groupId>com.liferay.portal</groupId>
-				<artifactId>portal-service</artifactId>
-				<version>${liferay.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.liferay.portal</groupId>
-				<artifactId>util-java</artifactId>
-				<version>${liferay.version}</version>
-				<scope>provided</scope>
 			</dependency>
 			<!-- J2EE dependencies -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,19 +57,7 @@
 				<artifactId>poi-ooxml</artifactId>
 				<version>3.17</version>
 			</dependency>
-			<!-- J2EE dependencies -->
-			<dependency>
-				<groupId>javax.portlet</groupId>
-				<artifactId>portlet-api</artifactId>
-				<version>2.0</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>3.0.1</version>
-				<scope>provided</scope>
-			</dependency>
+
 			<!-- command-line argument parsing -->
 			<dependency>
 				<groupId>info.picocli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>life.qbic</groupId>
 	<artifactId>parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
-	<version>1.7.0-SNAPSHOT</version>
+	<version>1.8.0-SNAPSHOT</version>
 	<name>Parent POM</name>
 	<description>Parent POM for all QBiC software</description>
 	<packaging>pom</packaging>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -43,40 +43,7 @@
 		</repository>
 	</repositories>
 	<dependencies>
-		<!-- Vaadin -->
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-server</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-client-compiled</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-themes</artifactId>
-		</dependency>
-		<!-- Liferay dependencies (provided by the servlet container) -->
-		<dependency>
-			<groupId>javax.portlet</groupId>
-			<artifactId>portlet-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.liferay.portal</groupId>
-			<artifactId>portal-service</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.liferay.portal</groupId>
-			<artifactId>util-java</artifactId>
-		</dependency>
+
 	</dependencies>
 	<build>
 		<plugins>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -6,9 +6,8 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>1.7.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
-	<groupId>life.qbic</groupId>
 	<artifactId>portal-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
 	<name>Portal parent POM</name>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -60,41 +60,7 @@
 					</filesets>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>com.vaadin</groupId>
-				<artifactId>vaadin-maven-plugin</artifactId>
-				<version>${vaadin.plugin.version}</version>
-				<configuration>
-					<extraJvmArgs>-Xmx512M -Xss1024k</extraJvmArgs>
-					<!-- We are doing "inplace" but into subdir VAADIN/widgetsets. This way compatible with Vaadin eclipse plugin. -->
-					<webappDirectory>${basedir}/src/main/webapp/VAADIN/widgetsets</webappDirectory>
-					<hostedWebapp>${basedir}/src/main/webapp/VAADIN/widgetsets</hostedWebapp>
-					<!-- Most Vaadin apps don't need this stuff, guide that to target -->
-					<persistentunitcachedir>${project.build.directory}</persistentunitcachedir>
-					<deploy>${project.build.directory}/gwt-deploy</deploy>
-					<!-- Compile report is not typically needed either, saves hundreds of disk -->
-					<compileReport>false</compileReport>
-					<noServer>true</noServer>
-					<!-- Remove draftCompile when project is ready -->
-					<draftCompile>false</draftCompile>
-					<style>OBF</style>
-				</configuration>
-				<executions>
-					<execution>
-						<configuration>
-							<!-- if you don't specify any modules, the plugin will find them -->
-						</configuration>
-						<goals>
-							<goal>clean</goal>
-							<goal>resources</goal>
-							<goal>update-theme</goal>
-							<goal>update-widgetset</goal>
-							<goal>compile-theme</goal>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+
 			<plugin>
 				<groupId>com.liferay.maven.plugins</groupId>
 				<artifactId>liferay-maven-plugin</artifactId>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -43,7 +43,40 @@
 		</repository>
 	</repositories>
 	<dependencies>
-
+		<!-- Vaadin -->
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-client-compiled</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-themes</artifactId>
+		</dependency>
+		<!-- Liferay dependencies (provided by the servlet container) -->
+		<dependency>
+			<groupId>javax.portlet</groupId>
+			<artifactId>portlet-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>portal-service</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>util-java</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -41,7 +41,65 @@
 			<name>QBiC Releases</name>
 			<url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
 		</repository>
+		<!-- vaadin repos -->
+		<repository>
+			<id>vaadin-addons</id>
+			<url>http://maven.vaadin.com/vaadin-addons</url>
+		</repository>
+		<repository>
+			<id>jcenter.bintray.com</id>
+			<url>https://jcenter.bintray.com</url>
+		</repository>
 	</repositories>
+	<dependencyManagement>
+		<dependencies>
+		<!-- Vaadin offers a bill of materials including all of the vaadin artifacts -->
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-bom</artifactId>
+			<version>${vaadin.version}</version>
+			<type>pom</type>
+			<scope>import</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin.addon</groupId>
+			<artifactId>vaadin-charts</artifactId>
+			<version>4.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.vaadin.addons</groupId>
+			<artifactId>vaadin-grid-util</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+		<!-- Liferay -->
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>portal-service</artifactId>
+			<version>${liferay.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>util-java</artifactId>
+			<version>${liferay.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<!-- J2EE dependencies -->
+		<dependency>
+			<groupId>javax.portlet</groupId>
+			<artifactId>portlet-api</artifactId>
+			<version>2.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.0.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+	</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<!-- Vaadin -->
 		<dependency>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -13,6 +13,10 @@
 	<name>Portal parent POM</name>
 	<description>Parent POM for all QBiC software that depends on a Liferay portal and Vaadin.</description>
 	<packaging>pom</packaging>
+	<properties>
+		<vaadin.version>8.9.2</vaadin.version>
+		<vaadin.plugin.version>8.9.2</vaadin.plugin.version>
+	</properties>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
 	<repositories>
 		<repository>
@@ -64,7 +68,7 @@
 		<dependency>
 			<groupId>com.vaadin.addon</groupId>
 			<artifactId>vaadin-charts</artifactId>
-			<version>4.2.0</version>
+			<version>3.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.vaadin.addons</groupId>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -12,6 +12,12 @@
 	<name>Portlet parent POM</name>
 	<description>Parent POM for all QBiC software that depends on a Liferay portal and Vaadin.</description>
 	<packaging>pom</packaging>
+	<properties>
+		<vaadin.version>8.9.2</vaadin.version>
+		<vaadin.plugin.version>8.9.2</vaadin.plugin.version>
+		<jetty.plugin.version>9.4.10.v20180503</jetty.plugin.version>
+		<jetty.scanIntervalSeconds>2</jetty.scanIntervalSeconds>
+	</properties>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
 	<repositories>
 		<repository>
@@ -41,6 +47,41 @@
 			<url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
 		</repository>
 	</repositories>
+	<dependencyManagement>
+		<dependencies>
+			<!-- Vaadin offers a bill of materials including all of the vaadin artifacts -->
+			<dependency>
+				<groupId>com.vaadin</groupId>
+				<artifactId>vaadin-bom</artifactId>
+				<version>${vaadin.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.vaadin.addon</groupId>
+				<artifactId>vaadin-charts</artifactId>
+				<version>4.2.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.vaadin.addons</groupId>
+				<artifactId>vaadin-grid-util</artifactId>
+				<version>1.0.0</version>
+			</dependency>
+			<!-- Liferay -->
+			<dependency>
+				<groupId>com.liferay.portal</groupId>
+				<artifactId>portal-service</artifactId>
+				<version>${liferay.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.liferay.portal</groupId>
+				<artifactId>util-java</artifactId>
+				<version>${liferay.version}</version>
+				<scope>provided</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<!-- Vaadin, Liferay and Servlet dependencies have been added in portal-parent-pom -->
 

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -122,7 +122,6 @@
 						</goals>
 						<configuration>
 							<scanIntervalSeconds>${jetty.scanIntervalSeconds}</scanIntervalSeconds>
-							<daemon>true</daemon>
 						</configuration>
 					</execution>
 					<execution>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -5,9 +5,8 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>portal-parent-pom</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.8.0-SNAPSHOT</version>
 	</parent>
-	<groupId>life.qbic</groupId>
 	<artifactId>portlet-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
 	<name>Portlet parent POM</name>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -89,6 +89,51 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>${jetty.plugin.version}</version>
+				<configuration>
+					<!-- Jetty's hot deploy enabled has been enabled by default!
+
+						 If you want to disable jetty's hot deploy feature, activate the 'jetty-cold-deploy' profile
+						 via the command line:
+
+						 mvn -P jetty-cold-deploy
+
+						 Or, alternatively, you can change your settings.xml to permanently activate this profile.
+
+						 For more information on how to permanently activate a property,
+						 see: https://maven.apache.org/settings.html#Profiles
+
+						 For more information about the origin of this long comment, see:
+						 https://github.com/qbicsoftware/parent-poms/issues/4 -->
+					<scanIntervalSeconds>${jetty.scanIntervalSeconds}</scanIntervalSeconds>
+					<useProvidedScope>true</useProvidedScope>
+					<stopPort>8005</stopPort>
+					<stopKey>STOP</stopKey>
+				</configuration>
+				<executions>
+					<execution>
+						<id>start-jetty</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>start</goal>
+						</goals>
+						<configuration>
+							<scanIntervalSeconds>${jetty.scanIntervalSeconds}</scanIntervalSeconds>
+							<daemon>true</daemon>
+						</configuration>
+					</execution>
+					<execution>
+						<id>stop-jetty</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<!-- enable resource filtering for war files -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -137,6 +137,41 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>com.vaadin</groupId>
+				<artifactId>vaadin-maven-plugin</artifactId>
+				<version>${vaadin.plugin.version}</version>
+				<configuration>
+					<extraJvmArgs>-Xmx512M -Xss1024k</extraJvmArgs>
+					<!-- We are doing "inplace" but into subdir VAADIN/widgetsets. This way compatible with Vaadin eclipse plugin. -->
+					<webappDirectory>${basedir}/src/main/webapp/VAADIN/widgetsets</webappDirectory>
+					<hostedWebapp>${basedir}/src/main/webapp/VAADIN/widgetsets</hostedWebapp>
+					<!-- Most Vaadin apps don't need this stuff, guide that to target -->
+					<persistentunitcachedir>${project.build.directory}</persistentunitcachedir>
+					<deploy>${project.build.directory}/gwt-deploy</deploy>
+					<!-- Compile report is not typically needed either, saves hundreds of disk -->
+					<compileReport>false</compileReport>
+					<noServer>true</noServer>
+					<!-- Remove draftCompile when project is ready -->
+					<draftCompile>false</draftCompile>
+					<style>OBF</style>
+				</configuration>
+				<executions>
+					<execution>
+						<configuration>
+							<!-- if you don't specify any modules, the plugin will find them -->
+						</configuration>
+						<goals>
+							<goal>clean</goal>
+							<goal>resources</goal>
+							<goal>update-theme</goal>
+							<goal>update-widgetset</goal>
+							<goal>compile-theme</goal>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>${jetty.plugin.version}</version>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -48,53 +48,7 @@
 		</repository>
 	</repositories>
 	<dependencyManagement>
-		<dependencies>
-			<!-- Vaadin offers a bill of materials including all of the vaadin artifacts -->
-			<dependency>
-				<groupId>com.vaadin</groupId>
-				<artifactId>vaadin-bom</artifactId>
-				<version>${vaadin.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.vaadin.addon</groupId>
-				<artifactId>vaadin-charts</artifactId>
-				<version>4.2.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.vaadin.addons</groupId>
-				<artifactId>vaadin-grid-util</artifactId>
-				<version>1.0.0</version>
-			</dependency>
-			<!-- Liferay -->
-			<dependency>
-				<groupId>com.liferay.portal</groupId>
-				<artifactId>portal-service</artifactId>
-				<version>${liferay.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.liferay.portal</groupId>
-				<artifactId>util-java</artifactId>
-				<version>${liferay.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<!-- J2EE dependencies -->
-			<dependency>
-				<groupId>javax.portlet</groupId>
-				<artifactId>portlet-api</artifactId>
-				<version>2.0</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>3.0.1</version>
-				<scope>provided</scope>
-			</dependency>
 
-		</dependencies>
 	</dependencyManagement>
 	<dependencies>
 		<!-- Vaadin, Liferay and Servlet dependencies have been added in portal-parent-pom -->

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -80,11 +80,58 @@
 				<version>${liferay.version}</version>
 				<scope>provided</scope>
 			</dependency>
+			<!-- J2EE dependencies -->
+			<dependency>
+				<groupId>javax.portlet</groupId>
+				<artifactId>portlet-api</artifactId>
+				<version>2.0</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>javax.servlet-api</artifactId>
+				<version>3.0.1</version>
+				<scope>provided</scope>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
 		<!-- Vaadin, Liferay and Servlet dependencies have been added in portal-parent-pom -->
-
+		<!-- Vaadin -->
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-client-compiled</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-themes</artifactId>
+		</dependency>
+		<!-- Liferay dependencies (provided by the servlet container) -->
+		<dependency>
+			<groupId>javax.portlet</groupId>
+			<artifactId>portlet-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>portal-service</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.liferay.portal</groupId>
+			<artifactId>util-java</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -98,40 +98,7 @@
 	</dependencyManagement>
 	<dependencies>
 		<!-- Vaadin, Liferay and Servlet dependencies have been added in portal-parent-pom -->
-		<!-- Vaadin -->
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-server</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-client-compiled</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-themes</artifactId>
-		</dependency>
-		<!-- Liferay dependencies (provided by the servlet container) -->
-		<dependency>
-			<groupId>javax.portlet</groupId>
-			<artifactId>portlet-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.liferay.portal</groupId>
-			<artifactId>portal-service</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.liferay.portal</groupId>
-			<artifactId>util-java</artifactId>
-		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>life.qbic</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>service-parent-pom</artifactId>
     <!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->


### PR DESCRIPTION
* Portlets now will run under Vaadin Version 8.9.x
* Some small refactoring of dependency definition: Portal application specific dependencies are now set in `portal-parent-pom` and not in the root pom `parent-pom` anymore 