### PR TITLE
Hotfix/2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.1 03-08-2020
+
+* Bump log4j core version to address a security vulnerarbility
+* Introduce core-utils-lib and data-model-lib in root pom
+
 ## 2.2.0
 
 * Include dependency for the Spock testing framework

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>2.2.0</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>cli-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<log4j.version>2.11.0</log4j.version>
+		<log4j.version>2.13.2</log4j.version>
 		<liferay.version>6.2.5</liferay.version>
 		<liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>
 		<powermock.version>2.0.0-beta.5</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>life.qbic</groupId>
 	<artifactId>parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
-	<version>2.2.0</version>
+	<version>${revision}</version>
 	<name>Parent POM</name>
 	<description>Parent POM for all QBiC software</description>
 	<packaging>pom</packaging>
@@ -16,6 +16,7 @@
 		<module>portal/portlet</module>
 	</modules>
 	<properties>
+		<revision>2.2.1</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -56,6 +57,16 @@
 				<groupId>org.apache.poi</groupId>
 				<artifactId>poi-ooxml</artifactId>
 				<version>3.17</version>
+			</dependency>
+			<dependency>
+				<groupId>life.qbic</groupId>
+				<artifactId>core-utils-lib</artifactId>
+				<version>1.6.0</version>
+			</dependency>
+			<dependency>
+				<groupId>life.qbic</groupId>
+				<artifactId>data-model-lib</artifactId>
+				<version>1.9.4</version>
 			</dependency>
 
 			<!-- command-line argument parsing -->

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>2.2.0</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>portal-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>portal-parent-pom</artifactId>
-		<version>2.2.0</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>portlet-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>life.qbic</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.2.0</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>service-parent-pom</artifactId>
     <!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->


### PR DESCRIPTION
* Bump log4j core version to address a security vulnerability
* Introduce core-utils-lib and data-model-lib in root pom