### PR TITLE
Bump data-model-lib to 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 			<dependency>
 				<groupId>life.qbic</groupId>
 				<artifactId>data-model-lib</artifactId>
-				<version>1.10.0</version>
+				<version>1.10.1</version>
 			</dependency>
 
       <!-- command-line argument parsing -->


### PR DESCRIPTION
Requires data-model-lib release 1.10.1
https://github.com/qbicsoftware/data-model-lib/pull/53