### PR TITLE
Include current version of mysql-connector-java in service-parent-pom

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -96,6 +96,11 @@
                 <artifactId>swagger-annotations</artifactId>
                 <version>2.0.8</version>
             </dependency>
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>8.0.21</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <!-- Micronaut service   framework dependencies -->


### PR DESCRIPTION
The main goal is to remove the current iteration which is based on explicit dependency inclusion with versioning of the mysql connector java in multiple portlets and to update the version at the same time