### PR TITLE
Increase JVM memory to 1GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2 2020-10-05
+
+* Increase Java memory during vaadin compilation to `-XmX1024m`
+  
 ## 3.1.1 2020-10-01
 
 * Update URL for QBiC's Maven repository ->

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.2</version>
 	</parent>
 	<artifactId>cli-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>life.qbic</groupId>
 	<artifactId>parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
-	<version>3.1.1-SNAPSHOT</version>
+	<version>3.1.2</version>
 	<name>Parent POM</name>
 	<description>Parent POM for all QBiC software</description>
 	<packaging>pom</packaging>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.2</version>
 	</parent>
 	<artifactId>portal-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -78,7 +78,7 @@
 				<artifactId>vaadin-maven-plugin</artifactId>
 				<version>${vaadin.plugin.version}</version>
 				<configuration>
-					<extraJvmArgs>-Xmx512M -Xss1024k</extraJvmArgs>
+					<extraJvmArgs>-Xmx1024m -Xss1024k</extraJvmArgs>
 					<!-- We are doing "inplace" but into subdir VAADIN/widgetsets. This way compatible with Vaadin eclipse plugin. -->
 					<webappDirectory>${basedir}/src/main/webapp/VAADIN/widgetsets</webappDirectory>
 					<hostedWebapp>${basedir}/src/main/webapp/VAADIN/widgetsets</hostedWebapp>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>portal-parent-pom</artifactId>
-		<version>3.1.1-SNAPSHOT</version>
+		<version>3.1.2</version>
 	</parent>
 	<artifactId>portlet-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>life.qbic</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>3.1.2</version>
     </parent>
     <artifactId>service-parent-pom</artifactId>
     <!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->


### PR DESCRIPTION
This commit increases the memory of the JVM during vaadin compilation to 1GB.
```
					<extraJvmArgs>-Xmx512m -Xss1024k</extraJvmArgs>
```
```
					<extraJvmArgs>-Xmx1024m -Xss1024k</extraJvmArgs>
```

The change is needed to allow for vaadin 8 compilation on systems running java 8 HotSpot versions.