### PR TITLE
This PR updates the order of repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.3 (2020-10-05)
+* As the most artefacts are hosted on Maven central
+we can speed up the build process when telling
+Maven to start dependency resolvement against Maven
+central first.
+
 ## 3.1.2 2020-10-05
 
 * Increase Java memory during vaadin compilation to `-XmX1024m`

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>3.1.2</version>
+		<version>3.1.3</version>
 	</parent>
 	<artifactId>cli-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -14,36 +14,6 @@
 	<description>Parent POM for all QBiC command-line interface (CLI) tools.</description>
 	<packaging>pom</packaging>
 
-	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
-	<repositories>
-		<repository>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</snapshots>
-			<id>nexus-snapshots</id>
-			<name>QBiC Snapshots</name>
-			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
-		</repository>
-		<repository>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>nexus-releases</id>
-			<name>QBiC Releases</name>
-			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>info.picocli</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -14,6 +14,49 @@
 	<description>Parent POM for all QBiC command-line interface (CLI) tools.</description>
 	<packaging>pom</packaging>
 
+	<!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
+	<repositories>
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>maven-central</id>
+			<name>Maven central</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</snapshots>
+			<id>nexus-snapshots</id>
+			<name>QBiC Snapshots</name>
+			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-snapshots</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>nexus-releases</id>
+			<name>QBiC Releases</name>
+			<url>https://qbic-repo.qbic.uni-tuebingen.de/repository/maven-releases</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>info.picocli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>life.qbic</groupId>
 	<artifactId>parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
-	<version>3.1.2</version>
+	<version>3.1.3</version>
 	<name>Parent POM</name>
 	<description>Parent POM for all QBiC software</description>
 	<packaging>pom</packaging>
@@ -157,6 +157,19 @@
   </dependencies>
   <repositories>
     <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>maven-central</id>
+      <name>Maven central</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
       <id>liferay-releases</id>
       <url>
         https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/portal/
@@ -191,6 +204,12 @@
     </snapshotRepository>
   </distributionManagement>
   <pluginRepositories>
+    <pluginRepository>
+      <id>maven-central-plugins</id>
+      <url>
+        https://repo.maven.apache.org/maven2
+      </url>
+    </pluginRepository>
     <pluginRepository>
       <id>liferay-releases-plugins</id>
       <url>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>3.1.2</version>
+		<version>3.1.3</version>
 	</parent>
 	<artifactId>portal-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -21,6 +21,19 @@
 	<repositories>
 		<repository>
 			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>maven-central</id>
+			<name>Maven central</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+		<repository>
+			<releases>
 				<enabled>false</enabled>
 			</releases>
 			<snapshots>

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>portal-parent-pom</artifactId>
-		<version>3.1.2</version>
+		<version>3.1.3</version>
 	</parent>
 	<artifactId>portlet-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -22,6 +22,19 @@
 	<repositories>
 		<repository>
 			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>maven-central</id>
+			<name>Maven central</name>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+		<repository>
+			<releases>
 				<enabled>false</enabled>
 			</releases>
 			<snapshots>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>life.qbic</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>3.1.2</version>
+        <version>3.1.3</version>
     </parent>
     <artifactId>service-parent-pom</artifactId>
     <!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -20,6 +20,19 @@
     <repositories>
         <repository>
             <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>maven-central</id>
+            <name>Maven central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+        <repository>
+            <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>


### PR DESCRIPTION
As the most artefacts are hosted on Maven central
we can speed up the build process when telling
Maven to start dependency resolvement against Maven
central first.