### PR TITLE
Hotfix/3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.1.4 (2020-10-06)
+* Removes unused flatten Maven plugin which will now not produce flatten
+  poms during build anymore
+
 ## 3.1.3 (2020-10-05)
 * As the most artefacts are hosted on Maven central
 we can speed up the build process when telling

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 	<artifactId>cli-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -457,33 +457,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Flattens the child poms to include the parent version for proper deployment-->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.2.2</version>
-        <configuration>
-          <flattenMode>ossrh</flattenMode>
-        </configuration>
-        <executions>
-          <!-- enable flattening -->
-          <execution>
-            <id>flatten</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>flatten</goal>
-            </goals>
-          </execution>
-          <!-- ensure proper cleanup -->
-          <execution>
-            <id>flatten.clean</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>life.qbic</groupId>
 	<artifactId>parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->
-	<version>3.1.3</version>
+	<version>3.1.4</version>
 	<name>Parent POM</name>
 	<description>Parent POM for all QBiC software</description>
 	<packaging>pom</packaging>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>parent-pom</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 	<artifactId>portal-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/portal/portlet/pom.xml
+++ b/portal/portlet/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>portal-parent-pom</artifactId>
-		<version>3.1.3</version>
+		<version>3.1.4</version>
 	</parent>
 	<artifactId>portlet-parent-pom</artifactId>
 	<!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>life.qbic</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.4</version>
     </parent>
     <artifactId>service-parent-pom</artifactId>
     <!-- if it's a release version, avoid using SNAPSHOT dependencies to avoid inconsistencies -->


### PR DESCRIPTION
This PR removes the unused flatten Maven plugin which will now not produce flatten poms during build anymore